### PR TITLE
docker-compose.yml improvements

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
   hytale-server:
+    image: ghcr.io/slowline/hytale-docker
     build: .
     container_name: hytale
     stdin_open: true


### PR DESCRIPTION
Hey! I have some suggestions to make the setup with the provided `docker-compose.yml` a bit easier.

1. On a linux host, you can mount your `/etc/machine-id` to use persistent server auth with the `/auth persistence Encrypted` command. I've only added it as comment, because this will otherwise fail when the file does not exist on the system.
2. I've added the provided pre-built image to the file so that the server setup is a bit easier. If you don't like that, I can also remove this from the pull request if you want.